### PR TITLE
Add script GreyNoise-Canary-Threat-Intel-Report.sh and update README.md

### DIFF
--- a/GreyNoise-Canary-Threat-Intel-Report.sh
+++ b/GreyNoise-Canary-Threat-Intel-Report.sh
@@ -8,7 +8,7 @@ export CANARY_HASH="abcd1234"
 export CANARY_TOKEN="11a2222bb3333c444d555e6f777ggg88"
 
 # Query Canary API for all events, extract IPs, remove double quotes, and write to a text file for GreyNoise
-curl https://$CANARY_HASH.canary.tools/api/v1/incidents/outside_bird/search -d auth_token=$CANARY_TOKEN -d node_ids="000103c21e6928dd" -G | jq '.src_ips[] | .ip_address' | sed 's/\"//g' | cat > canary-ips-$(date +%Y-%m-%d).txt
+curl https://$CANARY_HASH.canary.tools/api/v1/incidents/outside_bird/search -d auth_token=$CANARY_TOKEN -d node_ids="INSERT_NODE_IDS" -G | jq '.src_ips[] | .ip_address' | sed 's/\"//g' | cat > canary-ips-$(date +%Y-%m-%d).txt
 
 # Read through each line of the text file, send each IP to the GreyNoise Community API for context, and write the results to a JSON file
 file="canary-ips-$(date +%Y-%m-%d).txt"

--- a/GreyNoise-Canary-Threat-Intel-Report.sh
+++ b/GreyNoise-Canary-Threat-Intel-Report.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This script pulls alert data from an outside bird, sends the results to GreyNoise for threat intelligence context, and creates a report in json format. 
+# You will need to install the jq package and set your own CANARY_HASH and CANARY_TOKEN values ideally as environment variables since these are sensitive.
+# Canary support will be happy to enable API access to your console. See the README for further information.
+
+# Replace these placeholder values with your own
+export CANARY_HASH="abcd1234"
+export CANARY_TOKEN="11a2222bb3333c444d555e6f777ggg88"
+
+# Query Canary API for all events, extract IPs, remove double quotes, and write to a text file for GreyNoise
+curl https://$CANARY_HASH.canary.tools/api/v1/incidents/outside_bird/search -d auth_token=$CANARY_TOKEN -d node_ids="000103c21e6928dd" -G | jq '.src_ips[] | .ip_address' | sed 's/\"//g' | cat > canary-ips-$(date +%Y-%m-%d).txt
+
+# Read through each line of the text file, send each IP to the GreyNoise Community API for context, and write the results to a JSON file
+file="canary-ips-$(date +%Y-%m-%d).txt"
+lines=$(cat $file)
+
+for line in $lines
+do
+    curl "https://api.greynoise.io/v3/community/$line" | jq '.' | cat >> GreyNoise-Canary-Threat-Intel-Report-$(date +%Y-%m-%d).json
+done
+

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ In the future, we'll likely update this script to take a list of hosts from an e
 **Purpose:** A simple binary wrapper that will trigger a Canarytoken when a binary is executed.  
 **Link to Repo:** [singe/yellow](https://github.com/singe/yellow)
 
-<<<<<<< Updated upstream
 ### CanaryDeleter
 **Author:** Thinkst (Sherif)
 **Purpose:** Delete all incidents from a specific flock (using flock's name), or from a specific Canary device (using its NodeID); tool will optionally dump all incidents to a json file.
@@ -89,4 +88,4 @@ In the future, we'll likely update this script to take a list of hosts from an e
 **Author:** This bash script was kindly donated by a Thinkst customer.
 **Purpose:** This script is intended to run your alerts through the GreyNoise community API.
 **Usage:** Set the `CANARY_HASH` & `CANARY_TOKEN` variables, as well as the `BIRD_ID` you'd like to retrieve the events from. Run the script and the results will be populated in a new json file.
-**Prerequisites:** The API functionality will need to be enabled on your Console, a guide available [here](https://help.canary.tools/hc/en-gb/articles/360012727537-How-does-the-API-work-) package installed on your local machine. The script currently only supports outside Birds, a guide on how to enable this [here](https://help.canary.tools/hc/en-gb/articles/360017954338-Configuring-your-device-as-an-Outside-Bird).
+**Prerequisites:** The API functionality will need to be enabled on your Console, a guide available [here](https://help.canary.tools/hc/en-gb/articles/360012727537-How-does-the-API-work-). You will then need the {jq}(https://stedolan.github.io/jq/) package installed on your local machine. The script currently only supports outside Birds, a guide on how to enable this [here](https://help.canary.tools/hc/en-gb/articles/360017954338-Configuring-your-device-as-an-Outside-Bird).

--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ In the future, we'll likely update this script to take a list of hosts from an e
 **Author:** Dominic White (singe)  
 **Purpose:** A simple binary wrapper that will trigger a Canarytoken when a binary is executed.  
 **Link to Repo:** [singe/yellow](https://github.com/singe/yellow)
+
+<<<<<<< Updated upstream
+### CanaryDeleter
+**Author:** Thinkst (Sherif)
+**Purpose:** Delete all incidents from a specific flock (using flock's name), or from a specific Canary device (using its NodeID); tool will optionally dump all incidents to a json file.
+**Usage:**
+#### _Deleting all incidents from the default flock._
+`./CanaryDeleter -apikey $API_KEY -console $CONSOLE_HASH -flock "Default Flock"`
+#### _Deleting all incidents from a specific node, without dumping incidents to a json file_
+`./CanaryDeleter -apikey $API_KEY -console $CONSOLE_HASH -node 00034d476ff8e02d -dump=false`
+
+### GreyNoise-Canary-Threat-Intel-Report.sh
+**Author:** This bash script was kindly donated by a Thinkst customer.
+**Purpose:** This script is intended to run your alerts through the GreyNoise community API.
+**Usage:** Set the `CANARY_HASH` & `CANARY_TOKEN` variables, as well as the `BIRD_ID` you'd like to retrieve the events from. Run the script and the results will be populated in a new json file.
+**Prerequisites:** The API functionality will need to be enabled on your Console, a guide available [here](https://help.canary.tools/hc/en-gb/articles/360012727537-How-does-the-API-work-) package installed on your local machine. The script currently only supports outside Birds, a guide on how to enable this [here](https://help.canary.tools/hc/en-gb/articles/360017954338-Configuring-your-device-as-an-Outside-Bird).


### PR DESCRIPTION
This adds the aforementioned script which grabs Canary alert data from outside birds and sends to GreyNoise for threat intelligence context.