### PR TITLE
Update canary api2csv

### DIFF
--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -107,9 +107,9 @@ if [ $http_code -ne 200 ]; then
 fi
 
 # Check if we have state from the last incidents fetch
-if [ -f "${state_store_file_name}" ]; then
+if [ -f "$state_store_file_name" ]; then
     # We have state, so continue from last point and append to result file
-    incidents_since=`cat ${state_store_file_name}`
+    incidents_since=`cat $state_store_file_name`
     loaded_state=1
 fi
 
@@ -150,7 +150,7 @@ if [ $max_updated_id == "null" ]; then
     echo "No new events found on the console"
     exit 0
 else
-    echo $max_updated_id > last.txt
+    echo $max_updated_id > $state_store_file_name
 fi
 
 cursor=$(jq -r '.cursor | .next' <<< "$content")

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -52,6 +52,7 @@ sort_results () {
 
 stop () {
     sort_results
+    echo '' # Newline to not override status feedback
     if [ $loaded_state -ne 1 ]; then
         echo "Results saved in $results_file_name"
     else
@@ -61,6 +62,7 @@ stop () {
 }
 
 fail () {
+    echo '' # Newline to not override status feedback
     for arg in "$@"; do echo >&2 "$arg"; done
     exit 1
 }
@@ -117,7 +119,9 @@ if [ $loaded_state -ne 1 ]; then
     echo "No state found, fetching all incidents from the console. (This may take a while)"
 fi
 
-echo "Fetching incidents from console"
+echo "Fetching incidents from console: $base_url"
+echo -ne "Working: ."
+# echo -ne "/\r"
 
 # Get incidents
 response=$(curl $base_url/api/v1/incidents/all \
@@ -147,6 +151,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ $max_updated_id == "null" ]; then
+    echo '' # Newline to not override status feedback
     echo "No new events found on the console"
     exit 0
 else
@@ -173,11 +178,9 @@ if [ $cursor == "null" ]; then
 fi
 
 # While we have a pagination cursor keep loading data
-counter=1
 while [ cursor ]
 do
-    echo "Fetching additional incidents from console $counter"
-    ((counter=counter+1))
+    echo -ne "."
 
     response=$(curl $base_url/api/v1/incidents/all \
                 -d auth_token=$auth_token \

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -143,7 +143,7 @@ if [ "$data" != "" ]; then
     echo "$data" >> $FILE_NAME
 fi
 
-# There is not more data to read, we can stop
+# There is no more data to read, we can stop
 if [ $cursor == "null" ]; then
     stop
 fi
@@ -185,10 +185,8 @@ do
         echo "$data" >> $FILE_NAME
     fi
 
-    # There is not more data to read, we can stop
+    # There is no more data to read, we can stop
     if [ $cursor == "null" ]; then
-        break
+        stop
     fi
 done
-
-stop

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -124,7 +124,8 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ $max_updated_id == "null" ]; then
-    fail "No new events found on the console"
+    echo "No new events found on the console"
+    exit 0
 else
     echo $max_updated_id > last.txt
 fi

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -76,7 +76,7 @@ create_csv_header () {
     header+=",Target Port"
     header+=",Attacker"
     header+=",Attacker RevDNS"
-    # header+="Additional Events"
+    # header+=",Additional Events"
     echo "${header}" > $results_file_name
 }
 

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -15,15 +15,30 @@
 # Requires curl and jq to be in $PATH
 # sudo apt install curl jq
 
-# Configure the API authentication token and the domain hash of your console.
-# (Grab it here: https://1234abcd.canary.tools/settings where "1234abcd" is your unique console's CNAME)
-AUTH_TOKEN=deadbeef12345678
-DOMAIN_HASH=1234abcd
+# The only variable that need to be set is the AUTH_TOKEN and DOMAIN_HASH
+# They can be set as environmental variables or the the file below by
+# setting auth_token_default and domain_hash_default.
+# To fine the API auth token and domain hash go to the settings page of your console
+# (https://1234abcd.canary.tools/settings where "1234abcd" is your console's unique CNAME)
+auth_token_default=deadbeef12345678
+domain_hash_default=1234abcd
 
-# file_name=$(date "+%Y%m%d%H%M%S")-$DOMAIN_HASH-alerts.csv
+if [[ -z "${AUTH_TOKEN}" ]]; then
+    auth_token="$auth_token_default"
+else
+    auth_token="${AUTH_TOKEN}"
+fi
+
+if [[ -z "${DOMAIN_HASH}" ]]; then
+    domain_hash="${domain_hash_default}"
+else
+    domain_hash="${DOMAIN_HASH}"
+fi
+
+# file_name=$(date "+%Y%m%d%H%M%S")-$domain_hash-alerts.csv
 file_name=alerts.csv
 
-base_url="https://$DOMAIN_HASH.canary.tools"
+base_url="https://$domain_hash.canary.tools"
 page_size=500 # The number of incidents to get per page
 incidents_since=0 # Default to get all incidents
 loaded_state=0 # Boolean variable to track if previous state was recovered
@@ -75,7 +90,7 @@ fi
 
 # Ping the console to ensure reachability
 response=$(curl $base_url/api/v1/ping \
-            -d auth_token=$AUTH_TOKEN \
+            -d auth_token=$auth_token \
             --get --silent --show-error \
             --write-out '%{http_code}' 2>&1)
 if [ $? -ne 0 ]; then
@@ -106,7 +121,7 @@ echo "Fetching incidents from console"
 
 # Get incidents
 response=$(curl $base_url/api/v1/incidents/all \
-            -d auth_token=$AUTH_TOKEN \
+            -d auth_token=$auth_token \
             -d incidents_since=$incidents_since \
             -d limit=$page_size \
             -d shrink=true \
@@ -165,7 +180,7 @@ do
     ((counter=counter+1))
 
     response=$(curl $base_url/api/v1/incidents/all \
-                -d auth_token=$AUTH_TOKEN \
+                -d auth_token=$auth_token \
                 -d cursor=$cursor \
                 -d shrink=true \
                 --get --silent --show-error \

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -44,8 +44,8 @@ incidents_since=0 # Default to get all incidents
 loaded_state=0 # Boolean variable to track if previous state was recovered
 sort_on_column=1 # Set the column on which the csv should be sorted on update
 
-add_blank_notes_column=1 # Set to 1 to add a notes column to the csv that you can add notes too
-add_additional_event_details=1 # Set to 1 to add additional event details to the csv
+add_blank_notes_column=0 # Set to 1 to add a notes column to the csv that you can add notes too
+add_additional_event_details=0 # Set to 1 to add additional event details to the csv
 
 sort_results () {
     cp $results_file_name "$results_file_name.unsorted"

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -70,7 +70,10 @@ fail () {
 
 # To change what data is processed from the incidents update the create_csv_header and extract_incident_data functions
 create_csv_header () {
-    header="Updated ID,Date and Time"
+    header=""
+    # header+="Notes," # Uncomment to add header for blank notes column, remember to update sort_on_column 
+    header+="Updated ID"
+    header+=",Date and Time"
     header+=",Alert Description"
     header+=",Target"
     header+=",Target Port"
@@ -99,6 +102,7 @@ extract_incident_data () {
         fail "jq was unable to parse html content data" \
                 "Content: $content"
     fi
+    # data=$(echo "$data" | sed 's/^/,/g') # Uncomment to add blank notes column, remember to update sort_on_column
     echo "$data"
 }
 


### PR DESCRIPTION
Re-work the script to stop using the `newer_than` method that has been deprecated.

New features:

- The script received improved error checking and handling.
- Console api auth token and domain hash can be set as environmental variables
- Add a blank note column or additional details by setting the relevant boolean variables to 1
- Script uses the `incidents_since` parameter to only fetch new incidents and then keeps state for consecutive runs
- The script does pagination and fetches 500 events at a time
- If no state could be loaded the script will fetch all incidents on the console (may take a couple of minutes)