### PR TITLE
Canary api2csv python port

### DIFF
--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -34,7 +34,7 @@ results_file_name="${domain_hash}_alerts.csv"
 state_store_file_name="${domain_hash}_state_store.txt"
 
 base_url="https://$domain_hash.canary.tools"
-page_size=500 # The number of incidents to get per page
+page_size=1500 # The number of incidents to get per page
 incidents_since=0 # Default to get all incidents
 loaded_state=0 # Boolean variable to track if previous state was recovered
 sort_on_column=1 # Set the column on which the csv should be sorted on update; First column index is 1

--- a/bash/canary_api2csv.sh
+++ b/bash/canary_api2csv.sh
@@ -37,7 +37,7 @@ base_url="https://$domain_hash.canary.tools"
 page_size=500 # The number of incidents to get per page
 incidents_since=0 # Default to get all incidents
 loaded_state=0 # Boolean variable to track if previous state was recovered
-sort_on_column=1 # Set the column on which the csv should be sorted on update
+sort_on_column=1 # Set the column on which the csv should be sorted on update; First column index is 1
 
 add_blank_notes_column=0 # Set to 1 to add a notes column to the csv that you can add notes too
 add_additional_event_details=0 # Set to 1 to add additional event details to the csv
@@ -45,7 +45,7 @@ add_additional_event_details=0 # Set to 1 to add additional event details to the
 sort_results () {
     cp "$results_file_name" "$results_file_name.unsorted"
     head -n1 "$results_file_name.unsorted" > "$results_file_name" # Save the header in the file
-    tail -n+2 "$results_file_name.unsorted" | sort -t ',' -k $sort_on_column,$sort_on_column -n >> "$results_file_name" # Sort the file1
+    tail -n+2 "$results_file_name.unsorted" | sort -t ',' -k $sort_on_column,$sort_on_column -n >> "$results_file_name" # Sort the file
     rm -f "$results_file_name.unsorted"
 }
 
@@ -102,7 +102,7 @@ extract_incident_data () {
     description_fields+=",.src_host_reverse"
 
     if [ $add_additional_event_details -eq 1 ]; then
-        description_fields+=",(.events[] | tostring)"
+        description_fields+=",(.events | tostring)"
     fi
 
     if ! data=$(jq -r ".incidents[] | [
@@ -160,7 +160,6 @@ fi
 
 echo "Fetching incidents from console: $base_url"
 echo -ne "Working: ."
-# echo -ne "/\r"
 
 # Get incidents
 if ! response=$(curl "$base_url"/api/v1/incidents/all \

--- a/python/canary_api2csv.py
+++ b/python/canary_api2csv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Canary - API too CSV
+Canary - API to CSV
 This script is intended to get basic alert information into a SIEM. Rather than
 pulling full alert information, this script pulls just enough data to correlate
 Canary and Canarytoken alerts with other events or to trigger the IR process.

--- a/python/canary_api2csv.py
+++ b/python/canary_api2csv.py
@@ -57,7 +57,7 @@ while True:
         MAX_INT = int(MAX_INT/10)
 
 def _key(row):
-    return int(row[SORT_ON_COLUMN])
+    return row[SORT_ON_COLUMN]
 
 def sort_results():
     """Sort the csv file containing the results
@@ -99,12 +99,10 @@ def create_csv_header():
     """Function to write the csv file header
     """
 
-    global SORT_ON_COLUMN
     header = []
 
     if ADD_BLANK_NOTES_COLUMN:
         header.append("Notes")
-        SORT_ON_COLUMN += 1
 
     header.append("Updated ID")
     header.append("Date and Time")

--- a/python/canary_api2csv.py
+++ b/python/canary_api2csv.py
@@ -29,7 +29,7 @@ AUTH_TOKEN_DEFAULT = "deadbeef12345678"
 DOMAIN_HASH_DEFAULT = "1234abcd"
 
 # Customise the script output by configuring these optional variables
-PAGE_SIZE = 500 # The number of incidents to get per page
+PAGE_SIZE = 1500 # The number of incidents to get per page
 INCIDENTS_SINCE = 0 # 0 = Default to get all incidents
 SORT_ON_COLUMN = 0 # Column on which the csv should be sorted; First column index is 0
 ADD_BLANK_NOTES_COLUMN = False # Set True to add a notes column you can add notes too

--- a/python/canary_api2csv.py
+++ b/python/canary_api2csv.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Canary - API too CSV
+This script is intended to get basic alert information into a SIEM. Rather than
+pulling full alert information, this script pulls just enough data to correlate
+Canary and Canarytoken alerts with other events or to trigger the IR process.
+
+On first run the script will load all events from the console using pagination
+to prevent GET calls to the console from timing out.
+All consecutive runs of the script will only load new events and append them
+to the result file.
+The script keeps track of events exported and only pulls in new alerts.
+To reset this script, simply delete the {DOMAIN_HASH}_state_store.txt
+file saved alongside the results file {DOMAIN_HASH}_alerts.csv.
+"""
+
+import os
+import sys
+import json
+import requests
+
+# The only variable that need to be set is the AUTH_TOKEN and DOMAIN_HASH
+# They can be set as environmental variables or the the file below by
+# setting auth_token_default and domain_hash_default.
+# To fine the API auth token and domain hash go to the settings page of your console
+# (https://1234abcd.canary.tools/settings where "1234abcd" is your console's unique CNAME)
+AUTH_TOKEN_DEFAULT = "deadbeef12345678"
+DOMAIN_HASH_DEFAULT = "1234abcd"
+
+# Customise the script output by configuring these optional variables
+PAGE_SIZE = 500 # The number of incidents to get per page
+PAGE_SIZE = 1
+INCIDENTS_SINCE = 0 # 0 = Default to get all incidents
+SORT_ON_COLUMN = 1 # Set the column on which the csv should be sorted on update
+ADD_BLANK_NOTES_COLUMN = False # Set to True to add a notes column to the csv that you can add notes too
+ADD_ADDITIONAL_EVENT_DETAILS = False # Set to True to add additional event details to the csv
+
+# Use the environmental variables if set otherwise use the default variables
+AUTH_TOKEN = os.environ.get('AUTH_TOKEN', AUTH_TOKEN_DEFAULT)
+DOMAIN_HASH = os.environ.get('DOMAIN_HASH', DOMAIN_HASH_DEFAULT)
+
+# Prepare script variables
+RESULTS_FILE_NAME = f"{DOMAIN_HASH}_alerts.csv"
+STATE_STORE_FILE_NAME = f"{DOMAIN_HASH}_state_store.txt"
+BASE_URL = f"https://{DOMAIN_HASH}.canary.tools"
+LOADED_STATE = False # Boolean variable to track if previous state was recovered
+
+# sort_results () {
+#     cp "$RESULTS_FILE_NAME" "$RESULTS_FILE_NAME.unsorted"
+#     head -n1 "$RESULTS_FILE_NAME.unsorted" > "$RESULTS_FILE_NAME" # Save the header in the file
+#     tail -n+2 "$RESULTS_FILE_NAME.unsorted" | sort -t ',' -k $SORT_ON_COLUMN,$SORT_ON_COLUMN -n >> "$RESULTS_FILE_NAME" # Sort the file1
+#     rm -f "$RESULTS_FILE_NAME.unsorted"
+# }
+
+def stop():
+    """Print relevant message before exiting
+    """
+    # sort_results()
+    print('') # Newline to not override status feedback
+    if not LOADED_STATE:
+        print(f"Results saved in {RESULTS_FILE_NAME}")
+    else:
+        print(f"Updated results in {RESULTS_FILE_NAME}")
+    sys.exit(0)
+
+def fail(message :str):
+    """Print failure message before exiting
+
+    Args:
+        message (str): Message to print
+    """
+    print('') # Newline to not override status feedback
+    print(message)
+    sys.exit(1)
+
+# To change what data is processed from the incidents update
+# the create_csv_header and extract_incident_data functions
+def create_csv_header():
+    """Function to write the csv file header
+    """
+
+    header = ""
+
+    if ADD_BLANK_NOTES_COLUMN:
+        header += "Notes,"
+        # Increment the column sorting index by one
+        SORT_ON_COLUMN += 1
+
+    header += "Updated ID"
+    header += ",Date and Time"
+    header += ",Alert Description"
+    header += ",Target"
+    header += ",Target Port"
+    header += ",Attacker"
+    header += ",Attacker RevDNS"
+
+    if ADD_ADDITIONAL_EVENT_DETAILS:
+        header += ",Additional Events"
+
+    with open(RESULTS_FILE_NAME, 'w+', encoding='utf-8') as f:
+        f.write(f"{header}\n")
+
+def extract_incident_data(incidents: list) -> str:
+    """Process the incidents in the list and extract required information
+
+    Args:
+        incidents (list): Incidents to process
+
+    Returns:
+        str: String with csv data
+    """
+
+    incident_data = []
+    for incident in incidents:
+        data_line = ""
+        if ADD_BLANK_NOTES_COLUMN:
+            data_line += ","
+
+        data_line += f"{incident.get('updated_id', None)}"
+
+        description = incident.get('description', None)
+
+        data_line += f",{description.get('created_std', '')}"
+        data_line += f",{description.get('description', '')}"
+        data_line += f",{description.get('dst_host', '')}"
+        data_line += f",{description.get('dst_port', '')}"
+        data_line += f",{description.get('src_host', '')}"
+        data_line += f",{description.get('src_host_reverse', '')}"
+
+        if ADD_ADDITIONAL_EVENT_DETAILS:
+            data_line += f",{json.dumps(description.get('events', ''))}"
+
+        incident_data.append(data_line)
+
+    return '\n'.join(incident_data)
+
+# Ping the console to ensure reachability
+print("Check console is reachable")
+request_parameters = {
+    'auth_token': AUTH_TOKEN
+}
+try:
+    response = requests.get(
+        f"{BASE_URL}/api/v1/ping",
+        params=request_parameters,
+        timeout=30
+    )
+    response.raise_for_status()
+except requests.exceptions.HTTPError as error:
+    message = f"The console threw and HTTPError:\nError:{error}\nResponse: {response.text}"
+    fail(message=message)
+except requests.exceptions.RequestException as error:
+    message = f"Failed to communicate with the console:\n{error}"
+    fail(message=message)
+
+# Check if we have state from the last incidents fetch
+if os.path.exists(STATE_STORE_FILE_NAME):
+    # We have state, so continue from last point and append to result file
+    with open(STATE_STORE_FILE_NAME, 'r', encoding='utf-8') as f:
+        INCIDENTS_SINCE=f.read()
+    LOADED_STATE = True
+
+if not LOADED_STATE:
+    print("No state found, fetching all incidents from the console. (This may take a while)")
+
+print(f"Fetching incidents from console: {BASE_URL}")
+print("Working: .", end='')
+
+# Get incidents
+request_parameters = {
+    'auth_token': AUTH_TOKEN,
+    'incidents_since': INCIDENTS_SINCE,
+    'limit': PAGE_SIZE,
+    'shrink': 'true'
+}
+try:
+    response = requests.get(
+        f"{BASE_URL}/api/v1/incidents/all",
+        params=request_parameters,
+        timeout=30
+    )
+    response.raise_for_status()
+    json_data = response.json()
+    max_updated_id = json_data.get('max_updated_id', None)
+    cursor = json_data.get('cursor', [None]).get('next', None)
+    incidents = json_data.get('incidents', None)
+except requests.exceptions.JSONDecodeError as error:
+    message = f"Unable to process console return:\nError:{error}\nResponse: {response.text}"
+    fail(message=message)
+except requests.exceptions.HTTPError as error:
+    message = f"The console threw and HTTPError:\nError:{error}\nResponse: {response.text}"
+    fail(message=message)
+except requests.exceptions.RequestException as error:
+    message = f"Failed to communicate with the console:\n{error}"
+    fail(message=message)
+
+if max_updated_id is None:
+    print('') # Newline to not override status feedback
+    print("No new events found on the console")
+    sys.exit(0)
+else:
+    with open(STATE_STORE_FILE_NAME, 'w+', encoding='utf-8') as f:
+        f.write(f"{max_updated_id}")
+
+data = extract_incident_data(incidents)
+if data != "":
+    if not LOADED_STATE:
+        create_csv_header()
+    with open(RESULTS_FILE_NAME, 'a', encoding='utf-8') as f:
+        f.write(f"{data}\n")
+
+# There is no more data to read, we can stop
+if cursor is None:
+    stop()
+
+# While we have a pagination cursor keep loading data
+while cursor is not None:
+    print(".", end='')
+
+    request_parameters = {
+        'auth_token': AUTH_TOKEN,
+        'cursor': cursor,
+        'shrink': 'true'
+    }
+    try:
+        response = requests.get(
+            f"{BASE_URL}/api/v1/incidents/all",
+            params=request_parameters,
+            timeout=30
+        )
+        response.raise_for_status()
+        json_data = response.json()
+        cursor = json_data.get('cursor', [None]).get('next', None)
+        incidents = json_data.get('incidents', None)
+    except requests.exceptions.JSONDecodeError as error:
+        message = f"Unable to process console return:\nError:{error}\nResponse: {response.text}"
+        fail(message=message)
+    except requests.exceptions.HTTPError as error:
+        message = f"The console threw and HTTPError:\nError:{error}\nResponse: {response.text}"
+        fail(message=message)
+    except requests.exceptions.RequestException as error:
+        message = f"Failed to communicate with the console:\n{error}"
+        fail(message=message)
+
+    data = extract_incident_data(incidents)
+    if data != "":
+        with open(RESULTS_FILE_NAME, 'a', encoding='utf-8') as f:
+            f.write(f"{data}\n")
+
+    # There is no more data to read, we can stop
+    if cursor is None:
+        stop()


### PR DESCRIPTION
Python port of the bash version of api2csv script:

```
Canary - API to CSV
This script is intended to get basic alert information into a SIEM. Rather than
pulling full alert information, this script pulls just enough data to correlate
Canary and Canarytoken alerts with other events or to trigger the IR process.

On first run the script will load all events from the console using pagination
to prevent GET calls to the console from timing out.
All consecutive runs of the script will only load new events and append them
to the result file.
The script keeps track of events exported and only pulls in new alerts.
To reset this script, simply delete the {DOMAIN_HASH}_state_store.txt
file saved alongside the results file {DOMAIN_HASH}_alerts.csv.
```