### PR TITLE
Restrict permissions of prek github action

### DIFF
--- a/.github/workflows/format-prek.yml
+++ b/.github/workflows/format-prek.yml
@@ -10,6 +10,9 @@ env:
   VERSION: v0.3.10
   ARCH: x86_64-unknown-linux-gnu
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default permissions are too permissive.