### PR TITLE
Updated CanaryToken-deploy script

### DIFF
--- a/bash/CanaryToken-deploy.sh
+++ b/bash/CanaryToken-deploy.sh
@@ -19,7 +19,7 @@
 #    4. Run script as a user that has read/write access on the target directory.
 #
 #.EXAMPLE
-#    sh .\CreateCanarytokensCanaryToken-deploy.sh
+#    sh .\CanaryToken-deploy.sh
 #    This will run the tool asking interactively for missing params.
 #    Flags 
 #    -d Domain e.g aabbccdd.canary.tools
@@ -28,16 +28,13 @@
 #    -t Token Type e.g aws-id
 #    -n Token Filename e.g aws_secret.txt Note: Use an appropriate extension for your token type.
 #
-#    sh .\CreateCanarytokensCanaryToken-deploy.sh -d aabbccdd.canary.tools -a XXYYZZ -o "~/secret" -t aws-id -n aws_secret.txt
+#    sh .\CanaryToken-deploy.sh -d aabbccdd.canary.tools -a XXYYZZ -o "~/secret" -t aws-id -n aws_secret.txt
 #    creates an AWS-ID Canarytoken, using aws_secret.txt as the filename, and places it under ~/secret
 
 #   Supported tokens are: "aws-id"                : "AWS API Key",
-#                         "azure-id"              : "Azure API Key",
 #                         "credit-card"           : "Credit Card",
 #                         "doc-msword"            : "MS Word Document",
 #                         "msexcel-macro"         : "MS Excel Macro Document",
-#                         "msexcel-macro"         : "MS Excel Macro Document",
-#                         "msword-macro"          : "MS Word Macro Document",
 #                         "msword-macro"          : "MS Word Macro Document",
 #                         "mysql-dump"            : "MySQL Dump",
 #                         "pdf-acrobat-reader"    : "Acrobat PDF",
@@ -69,13 +66,13 @@ done
 #Collect unset variables from user.
 if [ -z "$TOKENTYPE" ]
 then
-echo '\nEnter your desired token type\n> aws-id | azure-id | credit-card | doc-msword | msexcel-macro | msexcel-macro | msword-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard'
+echo '\nEnter your desired token type\n> aws-id | credit-card | doc-msword | doc-msexcel | msexcel-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard'
 read TOKENTYPE
 fi
 
 #Don't continue unless $TOKENTYPE is supported
 case "$TOKENTYPE" in
-    "aws-id"|"azure-id"|"credit-card"|"doc-msword"|"msexcel-macro"|"msexcel-macro"|"msword-macro"|"msword-macro"|"mysql-dump"|"pdf-acrobat-reader"|"qr-code"|"slack-api"|"windows-dir"|"wireguard")
+    "aws-id"|"credit-card"|"doc-msword"|"doc-msexcel"|"msexcel-macro"|"msword-macro"|"mysql-dump"|"pdf-acrobat-reader"|"qr-code"|"slack-api"|"windows-dir"|"wireguard")
         echo '\n[*] Token type is downloadable, proceeding'
         ;;
     *)
@@ -141,7 +138,6 @@ echo "\nFile already exists." ;
 fi
 
 #Create token
-TOKENNAME=$OUTPUTFILENAME
 MACHINEHOSTNAME=$(hostname)
 
 echo "\n[*] Requesting a Token from the Canary Console API..." ;
@@ -158,7 +154,7 @@ if [[ "$TOKENRESULT" == *"success"* ]];
 then
 echo "\n[*] Token Created (ID: $TOKENID)."
 else
-echo "\n[X] Creation of $TOKENNAME failed."
+echo "\n[X] Creation of $OUTPUTFILENAME failed."
 exit -1
 fi
 

--- a/bash/CanaryToken-deploy.sh
+++ b/bash/CanaryToken-deploy.sh
@@ -66,13 +66,13 @@ done
 #Collect unset variables from user.
 if [ -z "$TOKENTYPE" ]
 then
-echo '\nEnter your desired token type\n> aws-id | credit-card | doc-msword | doc-msexcel | msexcel-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard'
+echo '\nEnter your desired token type\n> aws-id | azure-id | credit-card | doc-msword | doc-msexcel | msexcel-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard'
 read TOKENTYPE
 fi
 
 #Don't continue unless $TOKENTYPE is supported
 case "$TOKENTYPE" in
-    "aws-id"|"credit-card"|"doc-msword"|"doc-msexcel"|"msexcel-macro"|"msword-macro"|"mysql-dump"|"pdf-acrobat-reader"|"qr-code"|"slack-api"|"windows-dir"|"wireguard")
+    "aws-id"|"azure-id"|"credit-card"|"doc-msword"|"doc-msexcel"|"msexcel-macro"|"msword-macro"|"mysql-dump"|"pdf-acrobat-reader"|"qr-code"|"slack-api"|"windows-dir"|"wireguard")
         echo '\n[*] Token type is downloadable, proceeding'
         ;;
     *)

--- a/bash/CanaryToken-deploy.sh
+++ b/bash/CanaryToken-deploy.sh
@@ -1,93 +1,81 @@
 #!/bin/bash
 
 #.SYNOPSIS
-#    Adaption of Invoke-CreateCanarytokensFactoryLocal.ps1 to bash.
 #    Creates Canarytokens and drops them to local host.
-#    Uses Canarytoken Factory, so it can be safely used for mass deployment.
+#    Uses Canarytoken Deploy keys, so it can be safely used for mass deployment.
 #
 #.NOTES
 #    For this tool to work, you must have your Canary Console API enabled, please 
 #    follow this link to learn how to do so:
 #    https://help.canary.tools/hc/en-gb/articles/360012727537-How-does-the-API-work-
 #
-#    Also, you must have a Canarytoken Factory Auth, and the Flock *ID* you want to deploy to beforehand.
-#    if you don't know how, please reach out to support@canary.tools.
-#
 #    ###################
 #    How does this work?
 #    ###################
-#    Requires curl and jq to be in the path
-#    1. Create the flock you want the tokens to be part of in your Console.
-#    2. Get the Flock ID (https://docs.canary.tools/flocks/queries.html#list-flocks-summary)
-#    3. Create a Canarytoken Factory (https://docs.canary.tools/canarytokens/factory.html#create-canarytoken-factory-auth-string)
-#    4. Make sure the host has access to the internet.
-#    5. Run script as a user that has read/write access on the target directory.
-#    
-#    Last Edit: 2022-08-24
-#    Version 1.1 - release candidate
+#    Requires curl to be present.
+#    1. Create the Flock you want the Tokens to be part of in your Console.
+#    2. Create a Canarytoken Deploy Key (https://help.canary.tools/hc/en-gb/articles/7111549805213-Flock-API-Keys)
+#    3. Make sure the host has access to the internet.
+#    4. Run script as a user that has read/write access on the target directory.
 #
 #.EXAMPLE
-#    sh .\CreateCanarytokensFactoryLocal.sh
-#    This will run the tool with the default flock, asking interactively for missing params.
+#    sh .\CreateCanarytokensCanaryToken-deploy.sh
+#    This will run the tool asking interactively for missing params.
 #    Flags 
 #    -d Domain e.g aabbccdd.canary.tools
-#    -a FactoryAuth ""
-#    -f Flock ID e.g "flock:xxyyzz" Note: not setting the flock id will use "flock:default"
+#    -a APIKey "abc123"
 #    -o Output Directory e.g "~/secret"
 #    -t Token Type e.g aws-id
 #    -n Token Filename e.g aws_secret.txt Note: Use an appropriate extension for your token type.
 #
-#    sh .\CreateCanarytokensFactoryLocal.sh -d aabbccdd.canary.tools -a XXYYZZ -f flock:xxyyzz -o "~/secret" -t aws-id -n aws_secret.txt
+#    sh .\CreateCanarytokensCanaryToken-deploy.sh -d aabbccdd.canary.tools -a XXYYZZ -o "~/secret" -t aws-id -n aws_secret.txt
 #    creates an AWS-ID Canarytoken, using aws_secret.txt as the filename, and places it under ~/secret
 
 #   Supported tokens are: "aws-id"                : "AWS API Key",
+#                         "azure-id"              : "Azure API Key",
+#                         "credit-card"           : "Credit Card",
 #                         "doc-msword"            : "MS Word Document",
 #                         "msexcel-macro"         : "MS Excel Macro Document",
+#                         "msexcel-macro"         : "MS Excel Macro Document",
 #                         "msword-macro"          : "MS Word Macro Document",
+#                         "msword-macro"          : "MS Word Macro Document",
+#                         "mysql-dump"            : "MySQL Dump",
 #                         "pdf-acrobat-reader"    : "Acrobat PDF",
+#                         "qr-code"               : "QR Code",
 #                         "slack-api"             : "Slack API Key",
-#                         "windows-dir"           : "Windows Folder"
+#                         "windows-dir"           : "Windows Folder",
+#                         "wireguard"             : "Wireguard Config",
+
 
 #VARIABLES
 DOMAIN=""
-FACTORYAUTH=""
-FLOCKID="flock:default"
+APIKEY=""
 TARGETDIRECTORY=""
 TOKENTYPE=""
 TOKENFILENAME=""
 
 #Set script flags
-while getopts d:a:f:o:t:n: flag
+while getopts d:a:o:t:n: flag
 do
     case "${flag}" in
         d) DOMAIN=${OPTARG};;
-        a) FACTORYAUTH=${OPTARG};;
-        f) FLOCKID=${OPTARG};;
+        a) APIKEY=${OPTARG};;
         o) TARGETDIRECTORY=${OPTARG};;
         t) TOKENTYPE=${OPTARG};;
         n) TOKENFILENAME=${OPTARG};;
     esac
 done
 
-#Check for jq package
-if ! command -v jq &> /dev/null
-then
-echo '\n[X] jq package not found, please install : "sudo apt-get install jq"'
-exit -1
-else
-echo '\n[*] jq package found, proceeding'
-fi
-
 #Collect unset variables from user.
 if [ -z "$TOKENTYPE" ]
 then
-echo '\nEnter your desired token type\n> aws-id | doc-msword | msexcel-macro | msword-macro | pdf-acrobat-reader | slack-api | windows-dir'
+echo '\nEnter your desired token type\n> aws-id | azure-id | credit-card | doc-msword | msexcel-macro | msexcel-macro | msword-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard'
 read TOKENTYPE
 fi
 
 #Don't continue unless $TOKENTYPE is supported
 case "$TOKENTYPE" in
-    "aws-id"|"doc-msword"|"msexcel-macro"|"msword-macro"|"pdf-acrobat-reader"|"slack-api"|"windows-dir") 
+    "aws-id"|"azure-id"|"credit-card"|"doc-msword"|"msexcel-macro"|"msexcel-macro"|"msword-macro"|"msword-macro"|"mysql-dump"|"pdf-acrobat-reader"|"qr-code"|"slack-api"|"windows-dir"|"wireguard")
         echo '\n[*] Token type is downloadable, proceeding'
         ;;
     *)
@@ -102,10 +90,10 @@ echo '\nEnter your Full Canary domain (e.g. 'xyz.canary.tools')'
 read DOMAIN
 fi
 
-if [ -z "$FACTORYAUTH" ]
+if [ -z "$APIKEY" ]
 then
-echo '\nEnter your Canarytoken Factory Auth String'
-read FACTORYAUTH
+echo '\nEnter your Canarytoken API Key'
+read APIKEY
 fi
 
 if [ -z "$TARGETDIRECTORY" ]
@@ -127,7 +115,7 @@ fi
 #Print current variables
 echo "\n[*] Starting Script with the following params:"
 echo "\nConsole Domain = $DOMAIN"
-echo "\nFlock ID = $FLOCKID"
+echo "\nAPI Key = $APIKEY"
 echo "\nTarget Directory = $TARGETDIRECTORY"
 echo "\nToken Type = $TOKENTYPE"
 echo "\nToken Filename = $TOKENFILENAME" 
@@ -156,11 +144,15 @@ fi
 TOKENNAME=$OUTPUTFILENAME
 MACHINEHOSTNAME=$(hostname)
 
-echo "\n[*] Signing to the API for a token..." ;
+echo "\n[*] Requesting a Token from the Canary Console API..." ;
 
-GETTOKEN=$(curl -s -X POST "https://${DOMAIN}/api/v1/canarytoken/factory/create" -d factory_auth=$FACTORYAUTH -d memo="'"$MACHINEHOSTNAME" "-" "$TARGETDIRECTORY"/"$TOKENFILENAME"'" -d flock_id=$FLOCKID -d kind=$TOKENTYPE --tlsv1.2 --tls-max 1.2)
-TOKENRESULT=$(echo $GETTOKEN | jq -r ".result")
-TOKENID=$(echo $GETTOKEN | jq -r '.canarytoken.canarytoken')
+GETTOKEN=$(curl -s -X POST "https://${DOMAIN}/api/v1/canarytoken/create" \
+  -d auth_token="$APIKEY" \
+  -d memo="'$MACHINEHOSTNAME - $TARGETDIRECTORY/$TOKENFILENAME'" \
+  -d kind="$TOKENTYPE")
+
+[[ $GETTOKEN =~ \"result\":[[:space:]]*\"([^\"]+)\" ]]      && TOKENRESULT="${BASH_REMATCH[1]}"
+[[ $GETTOKEN =~ \"canarytoken\":[[:space:]]*\"([^\"]+)\" ]] && TOKENID="${BASH_REMATCH[1]}"
 
 if [[ "$TOKENRESULT" == *"success"* ]];
 then
@@ -173,6 +165,6 @@ fi
 #Download Token
 echo "\n[*] Downloading Token from Console..."
 
-curl -s -G -L --tlsv1.2 --tls-max 1.2 --output "$OUTPUTFILENAME" -J "https://$DOMAIN/api/v1/canarytoken/factory/download" -d factory_auth=$FACTORYAUTH -d canarytoken=$TOKENID
+curl -s -G -L --output "$OUTPUTFILENAME" -J "https://$DOMAIN/api/v1/canarytoken/download" -d auth_token="$APIKEY" -d canarytoken="$TOKENID"
 
 echo "\n[*] Token Successfully written to destination: '$OUTPUTFILENAME'."


### PR DESCRIPTION
- migrated script over to deploy keys.
- updated README
- updated list of supported token types
- dropped dependency on JQ

Test
```
g@Aspen bash % sh CanaryToken-deploy.sh
Enter your desired token type
> aws-id | credit-card | doc-msword | msexcel-macro | msexcel-macro | msword-macro | msword-macro | mysql-dump | pdf-acrobat-reader | qr-code | slack-api | windows-dir | wireguard
doc-msword
[*] Token type is downloadable, proceeding
Enter your Full Canary domain (e.g. xyz.canary.tools)
6b42426d.canary.tools
Enter your Canarytoken API Key
fa0...57d
Enter your target directory. Leave blank for ~/backup
/Users/g/Downloads
Enter your desired file name
helloworld.docx
[*] Starting Script with the following params:
Console Domain = 6b42426d.canary.tools
API Key = fa...7d
Target Directory = /Users/g/Downloads
Token Type = doc-msword
Token Filename = helloworld.docx
[*] Checking if '/Users/g/Downloads' exists...
Directory exists
[*] Dropping '/Users/g/Downloads/helloworld.docx'...
[*] Requesting a Token from the Canary Console API...
[*] Token Created (ID: i39pkuggqyy54pr6u3owdi65n).
[*] Downloading Token from Console...
[*] Token Successfully written to destination: '/Users/g/Downloads/helloworld.docx'.
```